### PR TITLE
Version 1.1.0

### DIFF
--- a/IxFree/Base.v
+++ b/IxFree/Base.v
@@ -173,14 +173,14 @@ Class IWorldLift (W : Type)
   through implication and logical equivalence. Again, see [LaterRules] module
   for details. *)
 
-(** *** Unlifting World to Lower Index *)
+(** *** Unlifting Worlds to Lower Index *)
 
 (** Other possible requirement on the world structure is world unlifting. *)
 
 Class IWorldUnliftCore (W : Type) : Type :=
   { world_unlift : W → W }.
 
-(** World unlifting can be seen as en inverse of world lifting (module world
+(** World unlifting can be seen as an inverse of world lifting (modulo world
   preorder), but we define it by giving the following conditions. *)
 
 Class IWorldUnlift (W : Type)
@@ -193,8 +193,8 @@ Class IWorldUnlift (W : Type)
 (** This definition is similar to the definition of [IWorldLift] class, but
   there is no condition analogous to [world_lift_limit_l], since a world
   may become less precise after unlifting. Moreover, [world_unlift_ord] makes
-  sense only for world with non-zero index. With these conditions it can be
-  easily shown, that unlifting is an inverse of lifting. *)
+  sense only for worlds with non-zero index. With these conditions it can be
+  easily shown that unlifting is an inverse of lifting. *)
 
 Lemma world_unlift_lift {W : Type} {PCW : PreOrderCore W} {ICW : IWorldCore W}
     {LCW : IWorldLiftCore W} {LW : IWorldLift W}

--- a/IxFree/Base.v
+++ b/IxFree/Base.v
@@ -166,7 +166,7 @@ Class IWorldUnliftCore (W : Type) : Type :=
 Class IWorldUnlift (W : Type)
     {PCW : PreOrderCore W} {ICW : IWorldCore W}
     {UCW : IWorldUnliftCore W} : Prop :=
-  { world_unlift_ord   : ∀ w, world_index w > 0 → w ⊏↓ world_unlift w
+  { world_unlift_ord   : ∀ w n, S n = world_index w → w ⊏↓ world_unlift w
   ; world_unlift_limit : ∀ w w', w ⊏↓ w' → world_unlift w ⊑ w'
   }.
 
@@ -188,5 +188,5 @@ Proof.
   + right; intros [ w' [ _ Hidx ] ].
     rewrite <- Heqn in Hidx; apply Nat.nlt_0_r in Hidx; assumption.
   + left; exists (world_unlift w).
-    apply world_unlift_ord; rewrite <- Heqn; apply Nat.lt_0_succ.
+    eapply world_unlift_ord; eassumption.
 Qed.

--- a/IxFree/Connectives.v
+++ b/IxFree/Connectives.v
@@ -233,59 +233,34 @@ End Exists.
 (** ** Later *)
 
 Section Later.
-  Context {IWC : IWorldCore W} {WC : IWorld W}.
+  Context {ICW : IWorldCore W} {IW : IWorld W}.
   Variables P : WProp W.
 
   Local Definition I_later_func (w : W) : Prop :=
-    ∀ w', w ⊑ w' → world_index w' < world_index w → w' ⊨ P.
+    ∀ w', w ⊏↓ w' → w' ⊨ P.
 
   Local Lemma I_later_monotone : monotone I_later_func.
   Proof.
-    intros w₁ w₂ Hw H w' Hw' Hidx; apply H.
-    + eapply preord_trans; eassumption.
-    + eapply Nat.lt_le_trans; [ eassumption | ].
-      apply world_index_ord; assumption.
+    intros w₁ w₂ Hw H w' Hw'; apply H.
+    eapply world_strict_preord_trans_l; eassumption.
   Qed.
 
   Definition I_later : WProp W :=
     {| ma_monotone := I_later_monotone |}.
 
   Lemma I_later_intro {w : W} :
-    (∀ w', w ⊑ w' → world_index w' < world_index w → w' ⊨ P) → w ⊨ I_later.
+    (∀ w', w ⊏↓ w' → w' ⊨ P) → w ⊨ I_later.
   Proof.
     intro H; constructor; exact H.
   Qed.
 
   Lemma I_later_elim {w w' : W} :
-    w ⊑ w' → world_index w' < world_index w → w ⊨ I_later → w' ⊨ P.
+    w ⊏↓ w' → w ⊨ I_later → w' ⊨ P.
   Proof.
-    intros Hw Hidx [ H ]; apply H; assumption.
+    intros Hw [ H ]; apply H; assumption.
   Qed.
 
   #[global] Opaque I_later.
-
-  Lemma I_later_zero {w : W} :
-    world_index w = 0 → w ⊨ I_later.
-  Proof.
-    intros Hidx; apply I_later_intro; rewrite Hidx.
-    intros w' _ Hlt.
-    inversion Hlt.
-  Qed.
-
-  Lemma I_loeb_induction {w : W} :
-    w ⊨ I_arrow I_later P → w ⊨ P.
-  Proof.
-    assert (LOEB : ∀ n w, world_index w < n → w ⊨ I_arrow I_later P → w ⊨ P).
-    { clear w; intro n; induction n; intros w Hlt H.
-      + inversion Hlt.
-      + apply (I_arrow_elim I_later _ H), I_later_intro.
-        intros w' Hord Hidx; apply IHn.
-        - eapply Nat.lt_le_trans; [ eassumption | ].
-          apply le_S_n, Hlt.
-        - eapply I_valid_monotone; eassumption.
-    }
-    eapply LOEB, le_n.
-  Qed.
 End Later.
 
 (* ========================================================================= *)

--- a/IxFree/LaterRules.v
+++ b/IxFree/LaterRules.v
@@ -191,11 +191,16 @@ Local Ltac loeb_induction_anon :=
 Local Ltac index_case_named HF :=
   lazymatch goal with
   | [ |- ?w ⊨ _ ] =>
-    let HProp := fresh "HProp" in
-    destruct (I_index_case w) as [ HF | HProp ];
-      [ | repeat lazymatch goal with
-                 | [ H: w ⊨ ▷(_)ᵢ |- _ ] => apply HProp in H
-                 end; clear HProp
+    let HProp  := fresh "HProp" in
+    let HFalse := fresh "HFalse" in
+    destruct (I_index_case w) as [ HFalse | HProp ];
+      [ revert HFalse;
+        repeat lazymatch goal with
+               | [ H: w ⊨ ▷(_)ᵢ |- _ ] => clear H
+               end; intro HF
+      | repeat lazymatch goal with
+               | [ H: w ⊨ ▷(_)ᵢ |- _ ] => apply HProp in H
+               end; clear HProp
       ]
   end.
 

--- a/IxFree/LaterRules.v
+++ b/IxFree/LaterRules.v
@@ -125,6 +125,14 @@ End Lift.
 Section Unlift.
   Context {UCW : IWorldUnliftCore W} {LW : IWorldUnlift W}.
 
+  Lemma I_world_unlift_later (P : WProp W) {w : W} :
+    (world_unlift w ⊨ P) → (w ⊨ ▷ P).
+  Proof.
+    intro H; apply I_later_intro; intros w' Hord.
+    eapply I_valid_monotone; [ | eassumption ].
+    apply world_unlift_limit; assumption.
+  Qed.
+
   Lemma I_disj_later_down (P Q : WProp W) {w : W} :
     (w ⊨ ▷(P ∨ᵢ Q)) → w ⊨ ▷P ∨ᵢ ▷Q.
   Proof.
@@ -132,14 +140,9 @@ Section Unlift.
     remember (world_index w) as n; destruct n as [ | n ].
     + ileft; apply I_later_zero; auto.
     + apply I_later_elim with (w' := world_unlift w) in H;
-        [ | apply world_unlift_ord; rewrite <- Heqn; apply Nat.lt_0_succ ].
-      idestruct H as H H.
-      - ileft; apply I_later_intro; intros w' Hord.
-        eapply I_valid_monotone; [ | eassumption ].
-        apply world_unlift_limit; assumption.
-      - iright; apply I_later_intro; intros w' Hord.
-        eapply I_valid_monotone; [ | eassumption ].
-        apply world_unlift_limit; assumption.
+        [ | eapply world_unlift_ord; eassumption ].
+      idestruct H as H H; [ ileft | iright ]; apply I_world_unlift_later;
+        assumption.
   Qed.
 
   Lemma I_exists_later_down (A : Type) (P : A → WProp W) (ex : A) {w : W} :
@@ -149,11 +152,9 @@ Section Unlift.
     remember (world_index w) as n; destruct n as [ | n ].
     + iexists ex; apply I_later_zero; auto.
     + apply I_later_elim with (w' := world_unlift w) in H;
-        [ | apply world_unlift_ord; rewrite <- Heqn; apply Nat.lt_0_succ ].
+        [ | eapply world_unlift_ord; eassumption ].
       idestruct H as x H; iexists x.
-      apply I_later_intro; intros w' Hord.
-      eapply I_valid_monotone; [ | eassumption ].
-      apply world_unlift_limit; assumption.
+      apply I_world_unlift_later; assumption.
   Qed.
 End Unlift.
 

--- a/IxFree/LaterRules.v
+++ b/IxFree/LaterRules.v
@@ -48,7 +48,7 @@ Proof.
   eapply LOEB, le_n.
 Qed.
 
-(** Most of later distribution laws do holds for any indexed structure of
+(** Most of later distribution laws do hold for any indexed structure of
   worlds. *)
 
 Lemma I_arrow_later_down (P Q : WProp W) {w : W} :
@@ -102,7 +102,7 @@ Proof.
 Qed.
 
 (* ========================================================================= *)
-(** ** Additional Laws That Relies on Existence of [world_lift] *)
+(** ** Additional Laws That Rely on Existence of [world_lift] *)
 
 Section Lift.
   Context {LCW : IWorldLiftCore W} {LW : IWorldLift W}.
@@ -186,8 +186,8 @@ Section BottomDec.
   Context {BW : IWorldBottomDec W}.
 
   (** Here we provide a lemma, that in synthetic form expresses the case
-    analysis on world index. We are in either locally minimal world (in a sense
-    of step-index), expressed as [▷(False)ᵢ], or not, which means that
+    analysis on world index. We are in either locally minimal world (in the
+    sense of step-index), expressed as [▷(False)ᵢ], or not, which means that
     [▷(P)ᵢ] implies [P]. For convenience, we also provide a tactic [index_case]
     that performs such an analysis. *)
 
@@ -247,9 +247,9 @@ Local Ltac index_case_named HF :=
 (* ------------------------------------------------------------------------- *)
 (** *** Löb Induction *)
 
-(** The key feature of step-indexed logic with later modality is an induction
+(** The key feature of step-indexed logic with later modality is induction
 over step-indices, called Löb induction. When the goal is [w ⊨ φ], these
-tactics introduces an assumption [w ⊨ ▷ φ]. The name of this assumption can
+tactics introduce an assumption [w ⊨ ▷ φ]. The name of this assumption can
 be provided as a parameter for [loeb_induction] tactic. If [loeb_induction]
 is used without a name, the default name [IH] is used. *)
 Tactic Notation "loeb_induction" := loeb_induction_anon.
@@ -260,11 +260,11 @@ Tactic Notation "loeb_induction" ident(H) := loeb_induction_named H.
 
 (** When the world structure implements an instance of [IWorldBottomDec], we
 can perform an analysis on the step-index by using [index_case] tactic. The
-tactic creates two subgoals. The first subgoal corresponds to the situation,
-that there is no future world with lower step-index, so we get additional
+tactic creates two subgoals. The first subgoal corresponds to the situation
+when there is no future world with lower step-index, so we get additional
 assumption [w ⊨ ▷(False)ᵢ]. The optional parameter to the tactic is the name
 of this assumption (the default name is [HFalse]). Since from false we can
-prove everything, all assumptions of the form [w ⊨ ▷(φ)] are cleared. In the
+deduce anything, all assumptions of the form [w ⊨ ▷(φ)] are cleared. In the
 second subgoal, all assumptions of the form [w ⊨ ▷(φ)ᵢ] are changed to [φ]. *)
 
 Tactic Notation "index_case" :=

--- a/IxFree/LaterRules.v
+++ b/IxFree/LaterRules.v
@@ -1,0 +1,212 @@
+(* This file is part of IxFree, released under MIT license.
+ * See LICENSE for details.
+ *)
+Require Import Utf8.
+Require Import IxFree.Base.
+Require Import IxFree.Connectives.
+Require Import IxFree.Tactics.
+Require Import PeanoNat.
+
+Import PreOrderNotations.
+
+Section LaterRules.
+
+Context {W : Type} {PCW : PreOrderCore W} {PW : PreOrder W}.
+Context {ICW : IWorldCore W} {IW : IWorld W}.
+
+Lemma I_later_zero (P : WProp W) {w : W} :
+  world_index w = 0 → w ⊨ ▷ P.
+Proof.
+  intro Hidx; apply I_later_intro.
+  intros w' [ _ Hlt ]; rewrite Hidx in Hlt; inversion Hlt.
+Qed.
+
+Lemma I_loeb_induction (P : WProp W) {w : W} :
+  (w ⊨ ▷ P →ᵢ P) → w ⊨ P.
+Proof.
+  assert (LOEB : ∀ n w, world_index w < n → (w ⊨ ▷ P →ᵢ P) → w ⊨ P).
+  { clear w; intro n; induction n; intros w Hlt H.
+    + inversion Hlt.
+    + apply (I_arrow_elim (▷P) _ H), I_later_intro.
+      intros w' [ Hord Hidx ]; apply IHn.
+      - eapply Nat.lt_le_trans; [ eassumption | ].
+        apply le_S_n, Hlt.
+      - eapply I_valid_monotone; eassumption.
+  }
+  eapply LOEB, le_n.
+Qed.
+
+Lemma I_arrow_later_down (P Q : WProp W) {w : W} :
+  (w ⊨ ▷(P →ᵢ Q)) → w ⊨ ▷P →ᵢ ▷Q.
+Proof.
+  intro H; iintro HP; later_shift; iapply H; assumption.
+Qed.
+
+Lemma I_conj_later_down (P Q : WProp W) {w : W} :
+  (w ⊨ ▷(P ∧ᵢ Q)) → w ⊨ ▷P ∧ᵢ ▷Q.
+Proof.
+  intro H; isplit; later_shift; iapply H.
+Qed.
+
+Lemma I_conj_later_up (P Q : WProp W) {w : W} :
+  (w ⊨ ▷P ∧ᵢ ▷Q) → w ⊨ ▷(P ∧ᵢ Q).
+Proof.
+  intro H; idestruct H as H1 H2; later_shift; isplit; assumption.
+Qed.
+
+Lemma I_iff_later_down (P Q : WProp W) {w : W} :
+  (w ⊨ ▷(P ↔ᵢ Q)) → w ⊨ ▷P ↔ᵢ ▷Q.
+Proof.
+  intro H; isplit; apply I_arrow_later_down; later_shift; apply H.
+Qed.
+
+Lemma I_disj_later_up (P Q : WProp W) {w : W} :
+  (w ⊨ ▷P ∨ᵢ ▷Q) → w ⊨ ▷(P ∨ᵢ Q).
+Proof.
+  intro H; idestruct H; later_shift; [ ileft | iright ]; assumption.
+Qed.
+
+Lemma I_forall_later_down (A : Type) (P : A → WProp W) {w : W} :
+  (w ⊨ ▷ ∀ᵢ x, P x) → w ⊨ ∀ᵢ x, ▷P x.
+Proof.
+  intro H; iintro x; later_shift; iapply H.
+Qed.
+
+Lemma I_forall_later_up (A : Type) (P : A → WProp W) {w : W} :
+  (w ⊨ ∀ᵢ x, ▷P x) → w ⊨ ▷ ∀ᵢ x, P x.
+Proof.
+  intro H; apply I_later_intro; intros w' Hord.
+  iintro x; apply I_forall_elim with (x:=x) in H.
+  eapply I_later_elim; eassumption.
+Qed.
+
+Lemma I_exists_later_up  (A : Type) (P : A → WProp W) {w : W} :
+  (w ⊨ ∃ᵢ x, ▷P x) → w ⊨ ▷ ∃ᵢ x, P x.
+Proof.
+  intro H; idestruct H as x H; later_shift; iexists x; assumption.
+Qed.
+
+Section Lift.
+  Context {LCW : IWorldLiftCore W} {LW : IWorldLift W}.
+
+  Lemma I_world_lift_later (P : WProp W) {w : W} :
+    (world_lift w ⊨ ▷ P) ↔ (w ⊨ P).
+  Proof.
+    split; intro HP.
+    + apply I_later_elim with (w' := w) in HP;
+        [ assumption | apply world_lift_ord ].
+    + apply I_later_intro; intros w' Hord.
+      eapply I_valid_monotone; [ | eassumption ].
+      apply world_lift_limit_l; assumption.
+  Qed.
+
+  Lemma I_arrow_later_up (P Q : WProp W) {w : W} :
+    (w ⊨ ▷P →ᵢ ▷Q) → w ⊨ ▷(P →ᵢ Q).
+  Proof.
+    intro H; apply I_later_intro; intros w₁ Hord₁.
+    apply I_arrow_intro; intros w₂ Hord₂ HP.
+    apply @I_valid_monotone with (w₂ := world_lift w₂) in H;
+      [ apply (I_arrow_elim (▷P) (▷Q)) in H | ].
+    + apply I_world_lift_later; assumption.
+    + apply I_world_lift_later; assumption.
+    + apply world_lift_limit_u.
+      eapply world_strict_preord_trans_r; eassumption.
+  Qed.
+
+  Lemma I_iff_later_up (P Q : WProp W) {w : W} :
+    (w ⊨ ▷P ↔ᵢ ▷Q) → w ⊨ ▷(P ↔ᵢ Q).
+  Proof.
+    intro H; idestruct H as H1 H2.
+    apply I_arrow_later_up in H1, H2; later_shift.
+    isplit; assumption.
+  Qed.
+End Lift.
+
+Section Unlift.
+  Context {UCW : IWorldUnliftCore W} {LW : IWorldUnlift W}.
+
+  Lemma I_disj_later_down (P Q : WProp W) {w : W} :
+    (w ⊨ ▷(P ∨ᵢ Q)) → w ⊨ ▷P ∨ᵢ ▷Q.
+  Proof.
+    intro H.
+    remember (world_index w) as n; destruct n as [ | n ].
+    + ileft; apply I_later_zero; auto.
+    + apply I_later_elim with (w' := world_unlift w) in H;
+        [ | apply world_unlift_ord; rewrite <- Heqn; apply Nat.lt_0_succ ].
+      idestruct H as H H.
+      - ileft; apply I_later_intro; intros w' Hord.
+        eapply I_valid_monotone; [ | eassumption ].
+        apply world_unlift_limit; assumption.
+      - iright; apply I_later_intro; intros w' Hord.
+        eapply I_valid_monotone; [ | eassumption ].
+        apply world_unlift_limit; assumption.
+  Qed.
+
+  Lemma I_exists_later_down (A : Type) (P : A → WProp W) (ex : A) {w : W} :
+    (w ⊨ ▷ ∃ᵢ x, P x) → w ⊨ ∃ᵢ x, ▷P x.
+  Proof.
+    intro H.
+    remember (world_index w) as n; destruct n as [ | n ].
+    + iexists ex; apply I_later_zero; auto.
+    + apply I_later_elim with (w' := world_unlift w) in H;
+        [ | apply world_unlift_ord; rewrite <- Heqn; apply Nat.lt_0_succ ].
+      idestruct H as x H; iexists x.
+      apply I_later_intro; intros w' Hord.
+      eapply I_valid_monotone; [ | eassumption ].
+      apply world_unlift_limit; assumption.
+  Qed.
+End Unlift.
+
+Section BottomDec.
+  Context {BW : IWorldBottomDec W}.
+
+  Lemma I_index_case (w : W) :
+    (w ⊨ ▷(False)ᵢ) ∨ (∀ P, (w ⊨ ▷(P)ᵢ) → P).
+  Proof.
+    destruct (world_bottom_dec w) as [ [ w' Hord ] | Hbot ].
+    + right; intros P HP.
+      apply (I_later_elim _ Hord), I_prop_elim in HP; assumption.
+    + left; apply I_later_intro.
+      intros w' Hord; apply I_prop_intro; eauto.
+  Qed.
+End BottomDec.
+
+End LaterRules.
+
+(* ========================================================================= *)
+(** ** Tactics *)
+
+Local Ltac loeb_induction_named IH :=
+  match goal with
+  | [ |- _ ⊨ ?P ] =>
+    apply (I_loeb_induction P);
+    iintro IH
+  end.
+
+Local Ltac loeb_induction_anon :=
+  let IH := fresh "IH" in
+  loeb_induction_named IH.
+
+Local Ltac index_case_named HF :=
+  lazymatch goal with
+  | [ |- ?w ⊨ _ ] =>
+    let HProp := fresh "HProp" in
+    destruct (I_index_case w) as [ HF | HProp ];
+      [ | repeat lazymatch goal with
+                 | [ H: w ⊨ ▷(_)ᵢ |- _ ] => apply HProp in H
+                 end; clear HProp
+      ]
+  end.
+
+(** The key feature of step-indexed logic with later modality is an induction
+over step-indices, called Löb induction. When the goal is [w ⊨ φ], these
+tactics introduces an assumption [w ⊨ ▷ φ]. The name of this assumption can
+be provided as a parameter for [loeb_induction] tactic. If [loeb_induction]
+is used without a name, the default name [IH] is used. *)
+Tactic Notation "loeb_induction" := loeb_induction_anon.
+Tactic Notation "loeb_induction" ident(H) := loeb_induction_named H.
+
+Tactic Notation "index_case" :=
+  let HFalse := fresh "HFalse" in
+  index_case_named HFalse.
+Tactic Notation "index_case" ident(H) := index_case_named H.

--- a/IxFree/Lib.v
+++ b/IxFree/Lib.v
@@ -3,6 +3,7 @@
  *)
 Require Export IxFree.Base.
 Require Export IxFree.Connectives.
+Require Export IxFree.LaterRules.
 Require Export IxFree.Tactics.
 Require Export IxFree.Relations.
 Require Export IxFree.AutoContr.

--- a/IxFree/Nat.v
+++ b/IxFree/Nat.v
@@ -58,7 +58,7 @@ Qed.
 Instance IWorldUnlift_NatWorld : IWorldUnlift NatWorld.
 Proof.
   split.
-  + intros [ n ] H; split; simpl; [ apply Nat.le_pred_l | ].
+  + intros [ n ] m H; split; simpl; [ apply Nat.le_pred_l | ].
     apply Nat.lt_pred_l; intro Heq; subst; inversion H.
   + intros [ n ] [ m ] [ _ Hidx ]; apply Nat.lt_le_pred; assumption.
 Qed.

--- a/IxFree/Nat.v
+++ b/IxFree/Nat.v
@@ -36,3 +36,29 @@ Proof. split; simpl; auto. Qed.
 Notation IProp    := (WProp NatWorld).
 Notation IRel     := (WRel NatWorld).
 Notation IRel_sig := (WRel_sig NatWorld).
+
+#[export]
+Instance IWorldLiftCore_NatWorld : IWorldLiftCore NatWorld :=
+  { world_lift w := {| nw_index := S (nw_index w) |} }.
+
+#[export]
+Instance IWorldUnliftCore_NatWorld : IWorldUnliftCore NatWorld :=
+  { world_unlift w := {| nw_index := pred (nw_index w) |} }.
+
+#[export]
+Instance IWorldLift_NatWorld : IWorldLift NatWorld.
+Proof.
+  split.
+  + intros [ n ]; repeat constructor.
+  + intros [ n ] [ m ] [ _ Hidx ]; apply PeanoNat.lt_n_Sm_le; assumption.
+  + intros [ n ] [ m ] [ _ Hidx ]; exact Hidx.
+Qed.
+
+#[export]
+Instance IWorldUnlift_NatWorld : IWorldUnlift NatWorld.
+Proof.
+  split.
+  + intros [ n ] H; split; simpl; [ apply Nat.le_pred_l | ].
+    apply Nat.lt_pred_l; intro Heq; subst; inversion H.
+  + intros [ n ] [ m ] [ _ Hidx ]; apply Nat.lt_le_pred; assumption.
+Qed.

--- a/IxFree/Tactics.v
+++ b/IxFree/Tactics.v
@@ -243,8 +243,7 @@ Local Ltac is_later H :=
 Local Ltac goal_is_later :=
   refine (_ : _ ⊨ ▷ _).
 
-(** Assuming that [Hord] has type [W ⊑ w'], and [Hidx] has type
-  [world_index w' < world_index w] it changes all assumptions of the
+(** Assuming that [Hord] has type [W ⊏↓ w'] it changes all assumptions of the
   form [W ⊨ ▷ φ] into [w' ⊨ φ]. *)
 Local Ltac move_later_assumptions W Hord :=
   repeat match goal with

--- a/IxFree/Tactics.v
+++ b/IxFree/Tactics.v
@@ -246,10 +246,10 @@ Local Ltac goal_is_later :=
 (** Assuming that [Hord] has type [W ⊑ w'], and [Hidx] has type
   [world_index w' < world_index w] it changes all assumptions of the
   form [W ⊨ ▷ φ] into [w' ⊨ φ]. *)
-Local Ltac move_later_assumptions W Hord Hidx :=
+Local Ltac move_later_assumptions W Hord :=
   repeat match goal with
   | [ H: W ⊨ ▷ ?P |- _ ] =>
-    apply (I_later_elim P Hord Hidx) in H
+    apply (I_later_elim P Hord) in H
   end.
 
 (** Introduce a later. It changes goal of the form [w ⊨ ▷ φ] into [w ⊨ φ],
@@ -259,23 +259,11 @@ Local Ltac iintro_later :=
   name_worlds ltac:(fun W_old W_new =>
     refine (I_later_intro _ _);
     let Hord := fresh "Hord" in
-    let Hidx := fresh "Hidx" in
-    intros W_new Hord Hidx;
-    move_later_assumptions W_old Hord Hidx;
-    move_assumptions W_old Hord;
-    try clear W_old Hord Hidx
+    intros W_new Hord;
+    move_later_assumptions W_old Hord;
+    move_assumptions W_old (proj1 Hord);
+    try clear W_old Hord
   ).
-
-Local Ltac loeb_induction_named IH :=
-  match goal with
-  | [ |- _ ⊨ ?P ] =>
-    apply (I_loeb_induction P);
-    iintro_arrow_named IH
-  end.
-
-Local Ltac loeb_induction_anon :=
-  let IH := fresh "IH" in
-  loeb_induction_named IH.
 
 (* ------------------------------------------------------------------------- *)
 (** *** Introduction rules *)
@@ -691,14 +679,3 @@ Tactic Notation "ispecialize" hyp(H) uconstr(t1) uconstr(t2) uconstr(t3)
   ispecialize_one H t5 ltac:(
   ispecialize_one H t6 ltac:(
   ispecialize_one H t7 idtac)))))).
-
-(* ========================================================================= *)
-(** ** Other tactics *)
-
-(** The key feature of step-indexed logic with later modality is an induction
-over step-indices, called Löb induction. When the goal is [w ⊨ φ], these
-tactics introduces an assumption [w ⊨ ▷ φ]. The name of this assumption can
-be provided as a parameter for [loeb_induction] tactic. If [loeb_induction]
-is used without a name, the default name [IH] is used. *)
-Tactic Notation "loeb_induction" := loeb_induction_anon.
-Tactic Notation "loeb_induction" ident(H) := loeb_induction_named H.

--- a/IxFree/UnaryFixpoint.v
+++ b/IxFree/UnaryFixpoint.v
@@ -5,6 +5,7 @@ Require Import Utf8.
 Require Import IxFree.Base.
 Require Import IxFree.Connectives.
 Require Import IxFree.Tactics.
+Require Import IxFree.LaterRules.
 Require Import PeanoNat.
 
 (** * Large Numbers and Unary Fixpoints *)
@@ -53,8 +54,9 @@ Section LargeNums.
   Lemma large_num_S {w : W} n :
     w ⊨ I_large_num (S n) →ᵢ ▷ I_large_num n.
   Proof.
-    iintros [ Hn ]; iintro; constructor.
-    eapply Nat.lt_le_trans; [ | apply Nat.lt_succ_r ]; eassumption.
+    iintros [ Hn ]; apply I_later_intro; intros w' Hord; constructor.
+    eapply Nat.lt_le_trans; [ apply Hord | ].
+    apply Nat.lt_succ_r; eassumption.
   Qed.
 
   #[global] Opaque I_large_num.

--- a/dune-project
+++ b/dune-project
@@ -5,6 +5,6 @@
 
 (package
   (name ixfree)
-  (version 1.0.0)
+  (version 1.1.0)
   (synopsis "Shallow embedding of internal logic of step-indexed logical relations")
   (description ""))


### PR DESCRIPTION
The new version of IxFree (1.1.0) introduces the following features and improvements.
- Definition and notation of strict preorder on worlds `w ⊏↓ w'`, i.e., when step index is strictly lower.
- Later-distribution laws for connectives;
- `IWorldLift` and `IWorldUnlift` typeclasses that provide operation of lifting and unlifting a step-index of given world. This optional structure of worlds is required for some later-distribution laws.
- `IWorldBottomDec` class that expresses decidability of the existence of a future world with lower step index.
- `index_case` tactic that provides inference rule for case analysis on the existence of a world described by `IWorldBottomDec` class.
- Instances of new classes for `Nat` worlds.
- Löb induction was moved to other module `LaterRules`, that contains other properties of later modality (distribution laws, index case analysis, etc.).