### PR TITLE
Large numbers

### DIFF
--- a/IxFree/LargeNum.v
+++ b/IxFree/LargeNum.v
@@ -9,9 +9,9 @@ Require Import IxFree.LaterRules.
 Require Import PeanoNat.
 
 (** * Large Numbers *)
-(** This module defines "large number" predicate. Intuitively, the number is
-  large, if it cannot cannot be distinguished from the infinity inside the
-  IxFree logic (assuming that decreasing the number requires moving to the
+(** This module defines the "large number" predicate. Intuitively, a number
+  is large if it cannot be distinguished from the infinity inside the
+  IxFree logic (assuming that decreasing the number requires moving to a
   later world). Large numbers are useful in defining complex recursive
   structures: they can be defined recursively on natural numbers, and for
   large numbers we get limit-like construction for free. For example, see
@@ -22,7 +22,7 @@ Section LargeNum.
 Context {W : Type} {PCW : PreOrderCore W} {PW : PreOrder W}.
 Context {IWC : IWorldCore W} {WC : IWorld W}.
 
-(** The number is large, if it is a successor of almost large number. *)
+(** The number is large if it is a successor of an almost large number. *)
 
 Fixpoint I_large (n : nat) : WProp W :=
   match n with

--- a/IxFree/LargeNum.v
+++ b/IxFree/LargeNum.v
@@ -1,0 +1,110 @@
+(* This file is part of IxFree, released under MIT license.
+ * See LICENSE for details.
+ *)
+Require Import Utf8.
+Require Import IxFree.Base.
+Require Import IxFree.Connectives.
+Require Import IxFree.Tactics.
+Require Import IxFree.LaterRules.
+Require Import IxFree.Relations.
+Require Import IxFree.AutoContr.
+
+Require IxFree.UnaryFixpoint.
+
+(** * Large Numbers *)
+(** This module defines "large number" predicate. Intuitively, the number is
+  large, if it cannot cannot be distinguished from the infinity inside the
+  IxFree logic (assuming that decreasing the number requires moving to the
+  later world). Large numbers are useful in defining complex recursive
+  structures: they can be defined recursively on natural numbers, and for
+  large numbers we get limit-like construction for free. *)
+
+Section LargeNum.
+
+Context {W : Type} {PCW : PreOrderCore W} {PW : PreOrder W}.
+Context {IWC : IWorldCore W} {WC : IWorld W}.
+
+(** The number is large, if it is a successor of almost large number. *)
+
+Local Definition I_large_F (I_large : nat ⇒ᵢ WRel W) : nat ⇒ᵢ WRel W :=
+  λ n, match n with
+       | 0   => (False)ᵢ
+       | S n => ▷ I_large n
+       end.
+
+Local Definition I_large_fix := I_fix I_large_F.
+Definition I_large := I_large_F I_large_fix.
+
+Local Lemma I_large_F_contractive : contractive I_large_F.
+Proof.
+  intro w; iintros R₁ R₂ HR []; simpl; auto_contr.
+Qed.
+
+Local Lemma I_large_roll w : w ⊨ I_large ≾ᵢ I_large_fix.
+Proof.
+  apply I_fix_roll, I_large_F_contractive.
+Qed.
+
+Local Lemma I_large_unroll w : w ⊨ I_large_fix ≾ᵢ I_large.
+Proof.
+  apply I_fix_unroll, I_large_F_contractive.
+Qed.
+
+(** Zero is not large. For successors, we can roll and unroll the
+  definition. *)
+
+Lemma I_large_Z w : ¬(w ⊨ I_large 0).
+Proof.
+  intro H; idestruct H; auto.
+Qed.
+
+Lemma I_large_S_intro n w : w ⊨ ▷ I_large n → w ⊨ I_large (S n).
+Proof.
+  intro H; simpl; iintro; iapply I_large_roll; assumption.
+Qed.
+
+Lemma I_large_S_elim n w : w ⊨ I_large (S n) → w ⊨ ▷ I_large n.
+Proof.
+  intro H; simpl in H; iintro; iapply I_large_unroll; assumption.
+Qed.
+
+#[global] Opaque I_large.
+
+Lemma I_large_is_S n w :
+  w ⊨ I_large n →ᵢ ∃ᵢ m (EQ : n = S m), ▷ I_large m.
+Proof.
+  iintro Hn; destruct n as [ | n ].
+  + exfalso; eapply I_large_Z; eassumption.
+  + iexists n; iexists; [ reflexivity | ].
+    iapply I_large_S_elim; assumption.
+Qed.
+
+Lemma I_large_le n m w :
+  n ≤ m → w ⊨ I_large n →ᵢ I_large m.
+Proof.
+  intro LE; revert w; induction LE; intro w; iintro Hn.
+  + assumption.
+  + apply I_large_S_intro; iintro.
+    iapply IHLE; assumption.
+Qed.
+
+(** Proving that large numbers exist is a bit tricky. Fortunately, we can
+  show that the auxiliary notion of large numbers from [UnaryFixpoint]
+  approximate large numbers from this module. *)
+
+Local Lemma I_large_num_is_large w :
+  w ⊨ ∀ᵢ n, UnaryFixpoint.I_large_num n →ᵢ I_large n.
+Proof.
+  loeb_induction; iintros n Hn.
+  iapply UnaryFixpoint.large_num_is_S in Hn.
+  idestruct Hn as m EQ Hm; subst.
+  apply I_large_S_intro; later_shift; iapply IH; assumption.
+Qed.
+
+Lemma I_large_exists (w : W) : w ⊨ ∃ᵢ n, I_large n.
+Proof.
+  idestruct (UnaryFixpoint.large_num_exists (w := w)) as n Hn.
+  iexists n; iapply I_large_num_is_large; assumption.
+Qed.
+
+End LargeNum.

--- a/IxFree/LaterRules.v
+++ b/IxFree/LaterRules.v
@@ -144,7 +144,7 @@ End Lift.
 (** ** Additional Laws That Relies on Existence of [world_unlift] *)
 
 Section Unlift.
-  Context {UCW : IWorldUnliftCore W} {LW : IWorldUnlift W}.
+  Context {UCW : IWorldUnliftCore W} {UW : IWorldUnlift W}.
 
   Lemma I_world_unlift_later (P : WProp W) {w : W} :
     (world_unlift w ⊨ P) → (w ⊨ ▷ P).

--- a/IxFree/Lib.v
+++ b/IxFree/Lib.v
@@ -7,3 +7,4 @@ Require Export IxFree.LaterRules.
 Require Export IxFree.Tactics.
 Require Export IxFree.Relations.
 Require Export IxFree.AutoContr.
+Require Export IxFree.LargeNum.

--- a/IxFree/Lib.v
+++ b/IxFree/Lib.v
@@ -5,6 +5,6 @@ Require Export IxFree.Base.
 Require Export IxFree.Connectives.
 Require Export IxFree.LaterRules.
 Require Export IxFree.Tactics.
+Require Export IxFree.LargeNum.
 Require Export IxFree.Relations.
 Require Export IxFree.AutoContr.
-Require Export IxFree.LargeNum.

--- a/IxFree/UnaryFixpoint.v
+++ b/IxFree/UnaryFixpoint.v
@@ -10,9 +10,9 @@ Require Import IxFree.LargeNum.
 
 (** * Unary Fixpoints *)
 (** This module provides some helper definitions and lemmas needed to define
-  general recursive predicates. We use to define recursive unary predicates as
-  fixpoints of contractive functions. Unary predicates are functions from
-  some type to world-indexed propositions. *)
+  general recursive predicates. We use [LargeNum] to define recursive unary
+  predicates as fixpoints of contractive functions. Unary predicates are
+  functions from some type to world-indexed propositions. *)
 
 Import PreOrderNotations.
 

--- a/IxFree/UnaryFixpoint.v
+++ b/IxFree/UnaryFixpoint.v
@@ -24,7 +24,15 @@ Context {IWC : IWorldCore W} {WC : IWorld W}.
   behind introducing large numbers is that if accessing the predecessor
   requires decreasing of a step-index, then large numbers are
   indistinguishable from infinite numbers. We will use this property to define
-  fixpoints of contractive functions. *)
+  fix-points of contractive functions.
+
+  Large numbers from this module are only the tool for proving the Banach
+  fixed-point theorem, and the user should not use them directly. The
+  [LargeNum] module provides a more convenient definition of large numbers,
+  that is defined in terms of guarded recursion and satisfies more properties.
+  In particular, the analog of the [I_large_S_intro] lemma would not hole in
+  general for the large numbers from this module, if not all world indices are
+  inhabited. *)
 
 Section LargeNums.
   Local Definition I_large_num_func n (w : W) : Prop := world_index w < n.
@@ -62,11 +70,11 @@ Section LargeNums.
   #[global] Opaque I_large_num.
 
   Lemma large_num_is_S {w : W} :
-    w ⊨ ∀ᵢ n, I_large_num n →ᵢ ∃ᵢ m, (n = S m)ᵢ ∧ᵢ ▷ I_large_num m.
+    w ⊨ ∀ᵢ n, I_large_num n →ᵢ ∃ᵢ m (EQ : n = S m), ▷ I_large_num m.
   Proof.
     iintros [ | n ] Hn.
     + exfalso; eapply large_num_Z; eassumption.
-    + iexists n; isplit; [ iintro; reflexivity | ].
+    + iexists n; iexists; [ reflexivity | ].
       iapply large_num_S; assumption.
   Qed.
 End LargeNums.
@@ -157,8 +165,7 @@ Section UFixpoint.
     iintro f_contr.
     idestruct (@large_num_exists w) as n Hn.
     iapply WRel1_equiv_trans; [ iapply I_fix1_n_equiv; eassumption | ].
-    iapply large_num_is_S in Hn; idestruct Hn as m Hnm Hm.
-    idestruct Hnm; subst; simpl.
+    iapply large_num_is_S in Hn; idestruct Hn as m Hnm Hm; subst; simpl.
     iapply f_contr.
     later_shift.
     iapply WRel1_equiv_symm; iapply I_fix1_n_equiv; assumption.

--- a/IxFree/UnaryFixpoint.v
+++ b/IxFree/UnaryFixpoint.v
@@ -6,11 +6,13 @@ Require Import IxFree.Base.
 Require Import IxFree.Connectives.
 Require Import IxFree.Tactics.
 Require Import IxFree.LaterRules.
-Require Import PeanoNat.
+Require Import IxFree.LargeNum.
 
-(** * Large Numbers and Unary Fixpoints *)
+(** * Unary Fixpoints *)
 (** This module provides some helper definitions and lemmas needed to define
-  general recursive predicates. *)
+  general recursive predicates. We use to define recursive unary predicates as
+  fixpoints of contractive functions. Unary predicates are functions from
+  some type to world-indexed propositions. *)
 
 Import PreOrderNotations.
 
@@ -19,171 +21,103 @@ Section UnaryFixpoint.
 Context {W : Type} {PCW : PreOrderCore W} {PW : PreOrder W}.
 Context {IWC : IWorldCore W} {WC : IWorld W}.
 
-(** ** Large Numbers *)
-(** Large numbers are numbers greater than current step index. The motivation
-  behind introducing large numbers is that if accessing the predecessor
-  requires decreasing of a step-index, then large numbers are
-  indistinguishable from infinite numbers. We will use this property to define
-  fix-points of contractive functions.
+Definition WRel1 (A : Type) : Type := A → WProp W.
 
-  Large numbers from this module are only the tool for proving the Banach
-  fixed-point theorem, and the user should not use them directly. The
-  [LargeNum] module provides a more convenient definition of large numbers,
-  that is defined in terms of guarded recursion and satisfies more properties.
-  In particular, the analog of the [I_large_S_intro] lemma would not hole in
-  general for the large numbers from this module, if not all world indices are
-  inhabited. *)
+Context {A : Type} (f : WRel1 A → WRel1 A).
 
-Section LargeNums.
-  Local Definition I_large_num_func n (w : W) : Prop := world_index w < n.
+(** We define equivalence of unary predicates as a pointwise world-indexed
+  equivalence. Note that this definition is a world-indexed predicate, so
+  we can use later operator to say that two predicates are almost
+  equivalent [(▷WRel1_equiv R₁ R₂)].  *)
 
-  Local Lemma I_large_num_monotone n : monotone (I_large_num_func n).
-  Proof.
-    intros w₁ w₂ Hw H.
-    eapply Nat.le_lt_trans; [ apply world_index_ord, Hw | exact H ].
-  Qed.
+Definition WRel1_equiv (R₁ R₂ : WRel1 A) : WProp W :=
+  ∀ᵢ x, R₁ x ↔ᵢ R₂ x.
 
-  Definition I_large_num n : WProp W :=
-    {| ma_monotone := I_large_num_monotone n |}.
+Lemma WRel1_equiv_symm w R₁ R₂ :
+  w ⊨ WRel1_equiv R₁ R₂ →ᵢ WRel1_equiv R₂ R₁.
+Proof.
+  iintros H x; isplit; iintro Hx; iapply H; assumption.
+Qed.
 
-  (** Large numbers exists, and they are always successors of almost
-    large numbers *)
+Lemma WRel1_equiv_trans w R₁ R₂ R₃ :
+  w ⊨ WRel1_equiv R₁ R₂ →ᵢ WRel1_equiv R₂ R₃ →ᵢ WRel1_equiv R₁ R₃.
+Proof.
+  iintros H1 H2 x; isplit.
+  + iintro H; iapply H2; iapply H1; assumption.
+  + iintro H; iapply H1; iapply H2; assumption.
+Qed.
 
-  Lemma large_num_exists {w : W} : w ⊨ ∃ᵢ n, I_large_num n.
-  Proof.
-    iexists (S (world_index w)); constructor; constructor.
-  Qed.
+(** We say that function is contractive if it maps almost equivalent
+  predicates to equivalent predicates. Contractive functions have
+  a fixpoint. *)
 
-  Lemma large_num_Z {w : W} : ¬(w ⊨ I_large_num 0).
-  Proof.
-    intros [ H ]; inversion H.
-  Qed.
+Definition I_contractive1 : WProp W :=
+  ∀ᵢ R₁ R₂, ▷ WRel1_equiv R₁ R₂ →ᵢ WRel1_equiv (f R₁) (f R₂).
 
-  Lemma large_num_S {w : W} n :
-    w ⊨ I_large_num (S n) →ᵢ ▷ I_large_num n.
-  Proof.
-    iintros [ Hn ]; apply I_later_intro; intros w' Hord; constructor.
-    eapply Nat.lt_le_trans; [ apply Hord | ].
-    apply Nat.lt_succ_r; eassumption.
-  Qed.
+(** A main observation needed to construct such a fixpoint is that when we
+  iterate a contractive function large number of times, the result does not
+  depend on the exact value of this number. *)
 
-  #[global] Opaque I_large_num.
+Local Fixpoint I_fix1_n (n : nat) : WRel1 A :=
+  match n with
+  | 0   => λ _, (False)ᵢ
+  | S n => f (I_fix1_n n)
+  end.
 
-  Lemma large_num_is_S {w : W} :
-    w ⊨ ∀ᵢ n, I_large_num n →ᵢ ∃ᵢ m (EQ : n = S m), ▷ I_large_num m.
-  Proof.
-    iintros [ | n ] Hn.
-    + exfalso; eapply large_num_Z; eassumption.
-    + iexists n; iexists; [ reflexivity | ].
-      iapply large_num_S; assumption.
-  Qed.
-End LargeNums.
+Local Lemma I_fix1_n_large w :
+  w ⊨ I_contractive1 →ᵢ
+    ∀ᵢ n m, I_large n →ᵢ I_large m →ᵢ
+    WRel1_equiv (I_fix1_n n) (I_fix1_n m).
+Proof.
+  iintro f_contr; loeb_induction.
+  iintros n m Hn Hm.
+  destruct n as [ | n ]; [ exfalso; eapply I_large_Z; eassumption | ].
+  destruct m as [ | m ]; [ exfalso; eapply I_large_Z; eassumption | ].
+  simpl in Hn, Hm; simpl; iapply f_contr.
+  iintro; iapply IH; assumption.
+Qed.
 
-(** ** Unary Fixpoints *)
-(** Here we will use large numbers to define recursive unary predicates as
-  fixpoints of contractive functions. Unary predicates are functions from
-  some type to world-indexed propositions. *)
+(** Therefore, we can define a fixpoint as any large iteration of a
+  function. *)
 
-Section UFixpoint.
-  Definition WRel1 (A : Type) : Type := A → WProp W.
+Definition I_fix1 : WRel1 A :=
+  λ x, ∀ᵢ n, I_large n →ᵢ I_fix1_n n x.
 
-  Context {A : Type} (f : WRel1 A → WRel1 A).
+Local Lemma I_fix1_n_equiv w :
+  w ⊨ I_contractive1 →ᵢ
+    ∀ᵢ n, I_large n →ᵢ WRel1_equiv I_fix1 (I_fix1_n n).
+Proof.
+  iintros f_contr n Hn x; isplit.
+  + iintros Hx; iapply Hx; assumption.
+  + iintros Hx m Hm.
+    iapply I_fix1_n_large;
+      [ exact f_contr | exact Hn | exact Hm | exact Hx ].
+Qed.
 
-  (** We define equivalence of unary predicates as a pointwise world-indexed
-    equivalence. Note that this definition is a world-indexed predicate, so
-    we can use later operator to say that two predicates are almost
-    equivalent [(▷WRel1_equiv R₁ R₂)].  *)
+Lemma I_fix1_is_fixpoint {w : W} :
+  w ⊨ I_contractive1 →ᵢ WRel1_equiv I_fix1 (f I_fix1).
+Proof.
+  iintro f_contr.
+  idestruct (I_large_exists w) as n Hn.
+  iapply WRel1_equiv_trans; [ iapply I_fix1_n_equiv; eassumption | ].
+  iapply I_large_is_S in Hn; idestruct Hn as m Hnm Hm; subst; simpl.
+  iapply f_contr.
+  later_shift.
+  iapply WRel1_equiv_symm; iapply I_fix1_n_equiv; assumption.
+Qed.
 
-  Definition WRel1_equiv (R₁ R₂ : WRel1 A) : WProp W :=
-    ∀ᵢ x, R₁ x ↔ᵢ R₂ x.
+#[global] Opaque I_fix1.
 
-  Lemma WRel1_equiv_symm w R₁ R₂ :
-    w ⊨ WRel1_equiv R₁ R₂ →ᵢ WRel1_equiv R₂ R₁.
-  Proof.
-    iintros H x; isplit; iintro Hx; iapply H; assumption.
-  Qed.
+Lemma I_fix1_unroll (w : W) x :
+  w ⊨ I_contractive1 →ᵢ I_fix1 x →ᵢ f I_fix1 x.
+Proof.
+  iintro f_contr; iapply I_fix1_is_fixpoint; assumption.
+Qed.
 
-  Lemma WRel1_equiv_trans w R₁ R₂ R₃ :
-    w ⊨ WRel1_equiv R₁ R₂ →ᵢ WRel1_equiv R₂ R₃ →ᵢ WRel1_equiv R₁ R₃.
-  Proof.
-    iintros H1 H2 x; isplit.
-    + iintro H; iapply H2; iapply H1; assumption.
-    + iintro H; iapply H1; iapply H2; assumption.
-  Qed.
-
-  (** We say that function is contractive if it maps almost equivalent
-    predicates to equivalent predicates. Contractive functions have
-    a fixpoint. *)
-
-  Definition I_contractive1 : WProp W :=
-    ∀ᵢ R₁ R₂, ▷ WRel1_equiv R₁ R₂ →ᵢ WRel1_equiv (f R₁) (f R₂).
-
-  (** A main observation needed to construct such a fixpoint is that when we
-    iterate a contractive function large number of times, the result does not
-    depend on the exact value of this number. *)
-
-  Local Fixpoint I_fix1_n (n : nat) : WRel1 A :=
-    match n with
-    | 0   => λ _, (False)ᵢ
-    | S n => f (I_fix1_n n)
-    end.
-
-  Local Lemma I_fix1_n_large w :
-    w ⊨ I_contractive1 →ᵢ
-      ∀ᵢ n m, I_large_num n →ᵢ I_large_num m →ᵢ
-      WRel1_equiv (I_fix1_n n) (I_fix1_n m).
-  Proof.
-    iintro f_contr; loeb_induction.
-    iintros n m Hn Hm.
-    destruct n as [ | n ]; [ exfalso; eapply large_num_Z; eassumption | ].
-    destruct m as [ | m ]; [ exfalso; eapply large_num_Z; eassumption | ].
-    iapply large_num_S in Hn; iapply large_num_S in Hm.
-    simpl; iapply f_contr.
-    iintro; iapply IH; assumption.
-  Qed.
-
-  (** Therefore, we can define a fixpoint as any large iteration of a
-    function. *)
-
-  Definition I_fix1 : WRel1 A :=
-    λ x, ∀ᵢ n, I_large_num n →ᵢ I_fix1_n n x.
-
-  Local Lemma I_fix1_n_equiv w :
-    w ⊨ I_contractive1 →ᵢ
-      ∀ᵢ n, I_large_num n →ᵢ WRel1_equiv I_fix1 (I_fix1_n n).
-  Proof.
-    iintros f_contr n Hn x; isplit.
-    + iintros Hx; iapply Hx; assumption.
-    + iintros Hx m Hm.
-      iapply I_fix1_n_large;
-        [ exact f_contr | exact Hn | exact Hm | exact Hx ].
-  Qed.
-
-  Lemma I_fix1_is_fixpoint {w : W} :
-    w ⊨ I_contractive1 →ᵢ WRel1_equiv I_fix1 (f I_fix1).
-  Proof.
-    iintro f_contr.
-    idestruct (@large_num_exists w) as n Hn.
-    iapply WRel1_equiv_trans; [ iapply I_fix1_n_equiv; eassumption | ].
-    iapply large_num_is_S in Hn; idestruct Hn as m Hnm Hm; subst; simpl.
-    iapply f_contr.
-    later_shift.
-    iapply WRel1_equiv_symm; iapply I_fix1_n_equiv; assumption.
-  Qed.
-
-  #[global] Opaque I_fix1.
-
-  Lemma I_fix1_unroll (w : W) x :
-    w ⊨ I_contractive1 →ᵢ I_fix1 x →ᵢ f I_fix1 x.
-  Proof.
-    iintro f_contr; iapply I_fix1_is_fixpoint; assumption.
-  Qed.
-
-  Lemma I_fix1_roll (w : W) x :
-    w ⊨ I_contractive1 →ᵢ f I_fix1 x →ᵢ I_fix1 x.
-  Proof.
-    iintro f_contr; iapply I_fix1_is_fixpoint; assumption.
-  Qed.
-End UFixpoint.
+Lemma I_fix1_roll (w : W) x :
+  w ⊨ I_contractive1 →ᵢ f I_fix1 x →ᵢ I_fix1 x.
+Proof.
+  iintro f_contr; iapply I_fix1_is_fixpoint; assumption.
+Qed.
 
 End UnaryFixpoint.


### PR DESCRIPTION
This commit provides another definition of large numbers, that has better properties than the definition from `UnaryFixpoint`. We found the notion of large numbers useful, so it becomes part of the public interface.

The old definition of large numbers is still needed, as the new definition is based on guarded recursion, which requires the old definition.